### PR TITLE
Add Contribution guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ Special thanks goes to the beautiful brains of the below listed packages. From y
 - [drf-yasg](https://github.com/axnsan12/drf-yasg)
 - [rest-api-payload](https://github.com/israelabraham/api-payload)
 - [django-sotp](https://github.com/israelabraham/django-sotp)
+
+## Contributing 
+
+Waiting for the contributing.md file to be updated. 


### PR DESCRIPTION
I see you have a Contribution.md file but it's not being referenced in the Root README file. 

I'd wait for you to update it and then add it here in the root README. 

Successfully merging this would close #8 